### PR TITLE
Fix code sample

### DIFF
--- a/users/06-get-user-presence-sessions.js
+++ b/users/06-get-user-presence-sessions.js
@@ -13,6 +13,7 @@ var config = require('../config')
 // ----------------------------------------------------------------------------
 const sprintf = require('sprintf-js').sprintf
 const UsersConnector = require('../connectors/UsersConnector.js')
+const HttpErrorHandler = require('../utils/Errors.js')
 
 // ----------------------------------------------------------------------------
 // Recursively get users from the API, one page at a time.


### PR DESCRIPTION
# What
Add a `require` line to `06-get-user-presence-sessions.js`

# Why
It was missing from this file and is needed to load the error handler.

