### PR TITLE
Fix chat code samples problem with dates "after" and "before"

### DIFF
--- a/chats/03-get-messages-of-one-chat.js
+++ b/chats/03-get-messages-of-one-chat.js
@@ -73,7 +73,7 @@ function getAllMessagesOfChatPromise(chatId, cursor, optionalSenderId, optionalA
       messagesCounter = messagesCounter + bodyWithPageOfMessages.data.length;
 
       if (bodyWithPageOfMessages.pagination.cursor != null) {
-        return getAllMessagesOfChatPromise(chatId, bodyWithPageOfMessages.pagination.cursor, optionalSenderId)
+        return getAllMessagesOfChatPromise(chatId, bodyWithPageOfMessages.pagination.cursor, optionalSenderId, optionalAfter, optionalBefore)
       } else {
         return Promise.resolve(messagesCounter)
       }

--- a/chats/05-get-uploads-of-one-chat.js
+++ b/chats/05-get-uploads-of-one-chat.js
@@ -72,7 +72,7 @@ function getAllUploadsOfChatPromise(chatId, cursor, optionalAfter, optionalBefor
       messagesCounter = messagesCounter + bodyWithPageOfUploads.data.length;
 
       if (bodyWithPageOfUploads.pagination.cursor != null) {
-        return getAllUploadsOfChatPromise(chatId, bodyWithPageOfUploads.pagination.cursor)
+        return getAllUploadsOfChatPromise(chatId, bodyWithPageOfUploads.pagination.cursor, optionalAfter, optionalBefore)
       } else {
         return Promise.resolve(messagesCounter)
       }


### PR DESCRIPTION
# What
Dates `after` and `before` were not being properly sent on requests to the developer api.
They were sent when requesting the first page of chat messages but not on the following ones and that caused these code samples to stop on page 2 with 0 requests.